### PR TITLE
fix: add pages plugin to storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,6 @@
 const { mergeConfig } = require('vite');
 const path = require('path');
+const Pages = require('vite-plugin-pages').default;
 
 module.exports = {
   'stories': [
@@ -28,7 +29,11 @@ module.exports = {
   },
   async viteFinal(config, { configType }) {
     return mergeConfig(config, {
-      // TODO add vite-plugin-pages w/o breaking
+      plugins: [
+        Pages({
+          extensions: ['vue']
+        })
+      ],
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '../src'),


### PR DESCRIPTION
Fixes #72
`require`ing the plugin needs to access the `default` export for it to work.