### PR TITLE
fix: set resolver as vue

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -31,7 +31,8 @@ module.exports = {
     return mergeConfig(config, {
       plugins: [
         Pages({
-          extensions: ['vue']
+          resolver: 'vue',
+          extensions: ['vue'],
         })
       ],
       resolve: {


### PR DESCRIPTION
Fixes #88 
For some reason the plugin wasn't inferring `vue` as the framework. That's why `~pages` alias was not working.